### PR TITLE
Bump django from 3.2.9 to 3.2.10

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,17 @@ Changelog
 This file contains a brief summary of new features and dependency changes or
 releases, in reverse chronological order.
 
+1.6.1 (202X-XX-XX)
+------------------
+
+Trivial/Internal Changes
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Bumped ``django`` from 3.2.9 to 3.2.10.
+
+
+----
+
 
 1.6.0 (2021-11-13)
 ------------------

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -30,7 +30,7 @@ click-repl==0.2.0
     # via celery
 coverage[toml]==6.1.2
     # via -r requirements/requirements-dev.in
-django==3.2.9
+django==3.2.10
     # via
     #   django-debug-toolbar
     #   django-extensions

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -30,7 +30,7 @@ click-repl==0.2.0
     # via celery
 cssselect==1.1.0
     # via pyquery
-django==3.2.9
+django==3.2.10
     # via
     #   -r requirements/requirements.in
     #   django-appconf


### PR DESCRIPTION
See: https://github.com/advisories/GHSA-v6rh-hp5x-86rv